### PR TITLE
Remove armv7 support and switch to iOS 11 SDK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-TARGET = iphone:latest:10.0
-ARCHS = armv7 arm64
+TARGET = iphone:latest:12.0
+ARCHS = arm64
 PACKAGE_VERSION = 1.2.2
 
 ifeq ($(SIDELOADED),1)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TARGET = iphone:latest:12.0
+TARGET = iphone:clang:latest:11.0
 ARCHS = arm64
 PACKAGE_VERSION = 1.2.2
 


### PR DESCRIPTION
Somehow clang is erroring out with armv7:
ld: warning: building for iOS, but linking in .tbd file (/home/nick/theos/vendor/lib/CydiaSubstrate.framework/CydiaSubstrate.tbd) built for iOS Simulator
ld: armv7 has no pc-rel bx thumb instruction. Can't fix up branch to _objc_autoreleaseReturnValue@0x00000000 in __ZL65_logos_property$_ungrouped$YTMainAppControlsOverlayView$pipButtonP28YTMainAppControlsOverlayViewP13objc_selector in '__ZL65_logos_property$_ungrouped$YTMainAppControlsOverlayView$pipButtonP28YTMainAppControlsOverlayViewP13objc_selector' from /home/nick/pip/.theos/obj/armv7/Tweak.xm.0d37458a.o
clang-10: error: linker command failed with exit code 1 (use -v to see invocation)