### PR TITLE
Update sideloaded instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,8 @@ make package FINALPACKAGE=1
 ### Sideloaded
 
 ```
-make package FINALPACKAGE=1 SIDELOADED=1
+make DEBUG=0 SIDELOADED=1
+mkdir out
+cp -r .theos/obj/com.ps.youpip.bundle/ .theos/obj/YouPiP.dylib out/
+rm out/com.ps.youpip.bundle/YouPiP.plist
 ```


### PR DESCRIPTION
Apparently the deb package had too much junk?
Since theos copies layout/ to root folder