### PR TITLE
Prevent crash and wrong display of version alert

### DIFF
--- a/Settings.x
+++ b/Settings.x
@@ -120,7 +120,7 @@ static NSString *YouPiPWarnVersionKey = @"YouPiPWarnVersionKey";
     currentVersion = [[NSBundle mainBundle] infoDictionary][(__bridge NSString *)kCFBundleVersionKey];
     if (![defaults boolForKey:YouPiPWarnVersionKey]) {
         if ([currentVersion compare:@(OS_STRINGIFY(MIN_YOUTUBE_VERSION)) options:NSNumericSearch] != NSOrderedAscending) {
-            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(3.0 * NSEC_PER_SEC)), dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(3.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
                 UIAlertController *warning = [UIAlertController alertControllerWithTitle:@"YouPiP" message:[NSString stringWithFormat:@"YouTube version %@ is not tested and may not be supported by YouPiP, please upgrade YouTube to at least version %s", currentVersion, OS_STRINGIFY(MIN_YOUTUBE_VERSION)] preferredStyle:UIAlertControllerStyleAlert];
                 UIAlertAction *action = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil];
                 [warning addAction:action];

--- a/Settings.x
+++ b/Settings.x
@@ -119,7 +119,7 @@ static NSString *YouPiPWarnVersionKey = @"YouPiPWarnVersionKey";
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     currentVersion = [[NSBundle mainBundle] infoDictionary][(__bridge NSString *)kCFBundleVersionKey];
     if (![defaults boolForKey:YouPiPWarnVersionKey]) {
-        if ([currentVersion compare:@(OS_STRINGIFY(MIN_YOUTUBE_VERSION)) options:NSNumericSearch] != NSOrderedAscending) {
+        if ([currentVersion compare:@(OS_STRINGIFY(MIN_YOUTUBE_VERSION)) options:NSNumericSearch] != NSOrderedDescending) {
             dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(3.0 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
                 UIAlertController *warning = [UIAlertController alertControllerWithTitle:@"YouPiP" message:[NSString stringWithFormat:@"YouTube version %@ is not tested and may not be supported by YouPiP, please upgrade YouTube to at least version %s", currentVersion, OS_STRINGIFY(MIN_YOUTUBE_VERSION)] preferredStyle:UIAlertControllerStyleAlert];
                 UIAlertAction *action = [UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleDefault handler:nil];


### PR DESCRIPTION
Using **dispatch_get_global_queue** results in YT app crashing. and since we're showing an alert,  we might as well **use dispatch_get_main_queue** that is meant to be used for UI updates. 

The version comparison isn't right either, it evaluates to true when the current version is not lesser than the  **MIN_YOUTUBE_VERSION**, and shows the alert on yt 16.46.5

