### PR TITLE
remove dependency: check for YouGroupSettings

### DIFF
--- a/Settings.x
+++ b/Settings.x
@@ -6,6 +6,7 @@
 #import <YouTubeHeader/YTSettingsSectionItem.h>
 #import <YouTubeHeader/YTSettingsSectionItemManager.h>
 #import <YouTubeHeader/YTAppSettingsSectionItemActionController.h>
+#import <YouTubeHeader/YTSettingsGroupData.h>
 
 #define LOC(x) [tweakBundle localizedStringForKey:x value:nil table:nil]
 
@@ -13,6 +14,10 @@ static const NSInteger YouPiPSection = 200;
 
 @interface YTSettingsSectionItemManager (YouPiP)
 - (void)updateYouPiPSectionWithEntry:(id)entry;
+@end
+
+@interface YTSettingsGroupData (YouGroupSettings)
++ (NSMutableArray *)tweaks;
 @end
 
 extern BOOL TweakEnabled();
@@ -135,6 +140,25 @@ static NSString *YouPiPWarnVersionKey = @"YouPiPWarnVersionKey";
         return;
     }
     %orig;
+}
+
+%end
+
+%hook YTSettingsGroupData
+
+- (NSArray *)orderedCategories {
+    if (self.type != 1) {
+        return %orig;
+    }
+
+    if (class_getClassMethod(%c(YTSettingsGroupData), @selector(tweaks))) {
+        return %orig;
+    }
+
+    NSMutableArray *mutableCategories = %orig.mutableCopy;
+    [mutableCategories insertObject:@(YouPiPSection) atIndex:0];
+
+    return [mutableCategories copy];
 }
 
 %end

--- a/Settings.x
+++ b/Settings.x
@@ -42,7 +42,7 @@ static NSString *YouPiPWarnVersionKey = @"YouPiPWarnVersionKey";
 
 %hook YTSettingsGroupData
 
-- (NSArray *)orderedCategories {
+- (NSArray <NSNumber *> *)orderedCategories {
     if (self.type != 1 || class_getClassMethod(objc_getClass("YTSettingsGroupData"), @selector(tweaks)))
         return %orig;
     NSMutableArray *mutableCategories = %orig.mutableCopy;

--- a/Settings.x
+++ b/Settings.x
@@ -2,6 +2,7 @@
 #import "Header.h"
 #import <YouTubeHeader/YTAlertView.h>
 #import <YouTubeHeader/YTHotConfig.h>
+#import <YouTubeHeader/YTSettingsGroupData.h>
 #import <YouTubeHeader/YTSettingsViewController.h>
 #import <YouTubeHeader/YTSettingsSectionItem.h>
 #import <YouTubeHeader/YTSettingsSectionItemManager.h>

--- a/control
+++ b/control
@@ -1,6 +1,6 @@
 Package: com.ps.youpip
 Name: YouPiP
-Depends: mobilesubstrate, com.ps.yougroupsettings, firmware (>= 11.0), firmware (>= 14.0) | gsc.ipad | com.ps.forceinpicture | com.cabralcole.forceinpicture
+Depends: mobilesubstrate, firmware (>= 11.0), firmware (>= 14.0) | gsc.ipad | com.ps.forceinpicture | com.cabralcole.forceinpicture
 Version: 1.0.0
 Architecture: iphoneos-arm
 Description: Enable native PiP in iOS YouTube app.


### PR DESCRIPTION
Since jailed iOS users might inject YouPiP without `YouGroupSettings` and then wonder where the tweak settings is, it could be better to check for the class method `tweaks` in the `YTSettingsGroupData`, and if it's not there, insert YouPiP at index 0 of the main section.