### PR TITLE
Change tweak name selector in YT settings

### DIFF
--- a/Settings.x
+++ b/Settings.x
@@ -136,9 +136,9 @@ static NSString *YouPiPWarnVersionKey = @"YouPiPWarnVersionKey";
     if ([delegate respondsToSelector:@selector(setSectionItems:forCategory:title:icon:titleDescription:headerHidden:)]) {
         YTIIcon *icon = [%c(YTIIcon) new];
         icon.iconType = YT_PIP;
-        [delegate setSectionItems:sectionItems forCategory:YouPiPSection title:TweakName icon:icon titleDescription:nil headerHidden:NO];
+        [delegate setSectionItems:sectionItems forCategory:YouPiPSection title:LOC(@"SETTINGS_TITLE") icon:icon titleDescription:nil headerHidden:NO];
     } else
-        [delegate setSectionItems:sectionItems forCategory:YouPiPSection title:TweakName titleDescription:nil headerHidden:NO];
+        [delegate setSectionItems:sectionItems forCategory:YouPiPSection title:LOC(@"SETTINGS_TITLE") titleDescription:nil headerHidden:NO];
 }
 
 - (void)updateSectionForCategory:(NSUInteger)category withEntry:(id)entry {

--- a/layout/Library/Application Support/YouPiP.bundle/ar.lproj/Localizable.strings
+++ b/layout/Library/Application Support/YouPiP.bundle/ar.lproj/Localizable.strings
@@ -1,5 +1,7 @@
 // Settings
 
+"SETTINGS_TITLE" = "YouPiP";
+
 "ENABLED" = "مفعَّل";
 "ENABLED_DESC" = "يجب إعادة تشغيل التطبيق.";
 

--- a/layout/Library/Application Support/YouPiP.bundle/de.lproj/Localizable.strings
+++ b/layout/Library/Application Support/YouPiP.bundle/de.lproj/Localizable.strings
@@ -1,5 +1,7 @@
 // Settings
 
+"SETTINGS_TITLE" = "YouPiP";
+
 "ENABLED" = "Aktiviert";
 "ENABLED_DESC" = "App-Neustart erforderlich!";
 

--- a/layout/Library/Application Support/YouPiP.bundle/en.lproj/Localizable.strings
+++ b/layout/Library/Application Support/YouPiP.bundle/en.lproj/Localizable.strings
@@ -1,5 +1,7 @@
 // Settings
 
+"SETTINGS_TITLE" = "YouPiP";
+
 "ENABLED" = "Enabled";
 "ENABLED_DESC" = "App restart is required.";
 

--- a/layout/Library/Application Support/YouPiP.bundle/es.lproj/Localizable.strings
+++ b/layout/Library/Application Support/YouPiP.bundle/es.lproj/Localizable.strings
@@ -1,5 +1,7 @@
 // Settings
 
+"SETTINGS_TITLE" = "YouPiP";
+
 "ENABLED" = "Activado";
 "ENABLED_DESC" = "Es necesario reiniciar la aplicación";
 

--- a/layout/Library/Application Support/YouPiP.bundle/fr.lproj/Localizable.strings
+++ b/layout/Library/Application Support/YouPiP.bundle/fr.lproj/Localizable.strings
@@ -1,5 +1,7 @@
 // Settings
 
+"SETTINGS_TITLE" = "YouPiP";
+
 "ENABLED" = "Enabled";
 "ENABLED_DESC" = "Le redémarrage de l'application est nécessaire.";
 

--- a/layout/Library/Application Support/YouPiP.bundle/hu.lproj/Localizable.strings
+++ b/layout/Library/Application Support/YouPiP.bundle/hu.lproj/Localizable.strings
@@ -1,5 +1,7 @@
 // Settings
 
+"SETTINGS_TITLE" = "YouPiP";
+
 "ENABLED" = "Engedélyezve";
 "ENABLED_DESC" = "Az alkalmazás újraindítása szükséges.";
 

--- a/layout/Library/Application Support/YouPiP.bundle/it.lproj/Localizable.strings
+++ b/layout/Library/Application Support/YouPiP.bundle/it.lproj/Localizable.strings
@@ -1,5 +1,7 @@
 // Settings
 
+"SETTINGS_TITLE" = "YouPiP";
+
 "ENABLED" = "Enabled";
 "ENABLED_DESC" = "È richiesto un riavvio dell'app.";
 

--- a/layout/Library/Application Support/YouPiP.bundle/ja.lproj/Localizable.strings
+++ b/layout/Library/Application Support/YouPiP.bundle/ja.lproj/Localizable.strings
@@ -1,5 +1,7 @@
 // Settings
 
+"SETTINGS_TITLE" = "YouPiP";
+
 "ENABLED" = "有効";
 "ENABLED_DESC" = "アプリの再起動が必要です。";
 

--- a/layout/Library/Application Support/YouPiP.bundle/ko.lproj/Localizable.strings
+++ b/layout/Library/Application Support/YouPiP.bundle/ko.lproj/Localizable.strings
@@ -1,5 +1,7 @@
 // Settings
 
+"SETTINGS_TITLE" = "YouPiP";
+
 "ENABLED" = "활성화";
 "ENABLED_DESC" = "앱 재시작이 필요합니다.";
 

--- a/layout/Library/Application Support/YouPiP.bundle/nl.lproj/Localizable.strings
+++ b/layout/Library/Application Support/YouPiP.bundle/nl.lproj/Localizable.strings
@@ -1,5 +1,7 @@
 // Settings
 
+"SETTINGS_TITLE" = "YouPiP";
+
 "ENABLED" = "Enabled";
 "ENABLED_DESC" = "App herstart is vereist.";
 

--- a/layout/Library/Application Support/YouPiP.bundle/pl.lproj/Localizable.strings
+++ b/layout/Library/Application Support/YouPiP.bundle/pl.lproj/Localizable.strings
@@ -1,5 +1,7 @@
 // Settings
 
+"SETTINGS_TITLE" = "Odtwarzaj w oknie (PiP)";
+
 "ENABLED" = "Włączone";
 "ENABLED_DESC" = "Wymaga ponownego uruchomienia aplikacji.";
 

--- a/layout/Library/Application Support/YouPiP.bundle/pt.lproj/Localizable.strings
+++ b/layout/Library/Application Support/YouPiP.bundle/pt.lproj/Localizable.strings
@@ -1,5 +1,7 @@
 // Settings
 
+"SETTINGS_TITLE" = "YouPiP";
+
 "ENABLED" = "Ativado";
 "ENABLED_DESC" = "A reinicialização do app é necessária.";
 

--- a/layout/Library/Application Support/YouPiP.bundle/ro.lproj/Localizable.strings
+++ b/layout/Library/Application Support/YouPiP.bundle/ro.lproj/Localizable.strings
@@ -1,5 +1,7 @@
 // Settings
 
+"SETTINGS_TITLE" = "YouPiP";
+
 "ENABLED" = "Enabled";
 "ENABLED_DESC" = "Este necesară repornirea aplicației.";
 

--- a/layout/Library/Application Support/YouPiP.bundle/ru.lproj/Localizable.strings
+++ b/layout/Library/Application Support/YouPiP.bundle/ru.lproj/Localizable.strings
@@ -1,5 +1,7 @@
 // Settings
 
+"SETTINGS_TITLE" = "YouPiP";
+
 "ENABLED" = "Активировать";
 "ENABLED_DESC" = "Потребуется перезапуск YouTube.";
 

--- a/layout/Library/Application Support/YouPiP.bundle/tr.lproj/Localizable.strings
+++ b/layout/Library/Application Support/YouPiP.bundle/tr.lproj/Localizable.strings
@@ -1,5 +1,7 @@
 // Settings
 
+"SETTINGS_TITLE" = "YouPiP";
+
 "ENABLED" = "Etkinleştir";
 "ENABLED_DESC" = "Uygulamanın yeniden başlatılması gerekir.";
 

--- a/layout/Library/Application Support/YouPiP.bundle/vi.lproj/Localizable.strings
+++ b/layout/Library/Application Support/YouPiP.bundle/vi.lproj/Localizable.strings
@@ -1,5 +1,7 @@
 // Settings
 
+"SETTINGS_TITLE" = "YouPiP";
+
 "ENABLED" = "Kích hoạt";
 "ENABLED_DESC" = "Cần khởi động lại ứng dụng.";
 

--- a/layout/Library/Application Support/YouPiP.bundle/zh_cn.lproj/Localizable.strings
+++ b/layout/Library/Application Support/YouPiP.bundle/zh_cn.lproj/Localizable.strings
@@ -1,5 +1,7 @@
 // Settings
 
+"SETTINGS_TITLE" = "YouPiP";
+
 "ENABLED" = "启用";
 "ENABLED_DESC" = "更改本设置后需要重启App。";
 

--- a/layout/Library/Application Support/YouPiP.bundle/zh_tw.lproj/Localizable.strings
+++ b/layout/Library/Application Support/YouPiP.bundle/zh_tw.lproj/Localizable.strings
@@ -1,5 +1,7 @@
 ﻿// Settings
 
+"SETTINGS_TITLE" = "YouPiP";
+
 "ENABLED" = "啟用";
 "ENABLED_DESC" = "需要重新啟動應用程式。";
 


### PR DESCRIPTION
I think a better solution is to use a tweak short description in the settings instead of the name. Current if someone doesn't know English, they may not understand what the tweak is for.

Maybe I didn't do it according to good iOS programming practices _(sorry, it's not my primary programming language)._

The effect I want:
![image](https://github.com/user-attachments/assets/b36ba82b-3de9-409b-800b-bdf68b9f11b8)
(YouGroupSetting tweak is used too)