### PR TITLE
Fix settings crash

### DIFF
--- a/Settings.x
+++ b/Settings.x
@@ -31,11 +31,14 @@ static NSString *YouPiPWarnVersionKey = @"YouPiPWarnVersionKey";
 
 %hook YTAppSettingsPresentationData
 
-+ (NSMutableArray <NSNumber *> *)settingsCategoryOrder {
-    NSMutableArray <NSNumber *> *order = %orig;
++ (NSArray <NSNumber *> *)settingsCategoryOrder {
+    NSArray <NSNumber *> *order = %orig;
     NSUInteger insertIndex = [order indexOfObject:@(1)];
-    if (insertIndex != NSNotFound)
-        [order insertObject:@(YouPiPSection) atIndex:insertIndex + 1];
+    if (insertIndex != NSNotFound) {
+        NSMutableArray *mutableOrder = order.mutableCopy;
+        [mutableOrder insertObject:@(YouPiPSection) atIndex:insertIndex + 1];
+        order = mutableOrder.copy;
+    }
     return order;
 }
 


### PR DESCRIPTION
`settingsCategoryOrder` is indeed an NSArray, so a mutable copy needs to be created first.

This fix (or something similar) will need to be applied to the other repos which utilize this hook as well.