### PR TITLE
fix: build with plistutil fails

### DIFF
--- a/layout/Library/Application Support/YouPiP.bundle/zh_tw.lproj/Localizable.strings
+++ b/layout/Library/Application Support/YouPiP.bundle/zh_tw.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-﻿"SETTINGS_TITLE" = "YouPiP";
+"SETTINGS_TITLE" = "YouPiP";
 
 "ENABLED" = "啟用";
 "ENABLED_DESC" = "需要重新啟動應用程式。";


### PR DESCRIPTION
## Proposed changes
- Remove extra characters in the beginning of `zh_tw` localization to fix build with `plistutil` (https://github.com/libimobiledevice/libplist)

## Issue

When I tried building this package on Ubuntu with latest plistutil it failed:
```
❯ make clean package FINALPACKAGE=1
==> Cleaning…
> Making all for tweak YouPiP…
==> Preprocessing Settings.x…
==> Preprocessing Tweak.x…
==> Preprocessing LegacyPiPCompat.x…
==> Compiling Settings.x (arm64)…
==> Compiling LegacyPiPCompat.x (arm64)…
==> Compiling Tweak.x (arm64)…
==> Linking tweak YouPiP (arm64)…
==> Stripping YouPiP (arm64)…
==> Signing YouPiP…
> Making stage for tweak YouPiP…
ERROR: Could not parse plist data (-3)
```

By patching theos I figured out that error happens when parsing https://github.com/PoomSmart/YouPiP/blob/main/layout/Library/Application%20Support/YouPiP.bundle/zh_tw.lproj/Localizable.strings. Removing this file confirmed it as the issue went away.

Then I recompiled libplist with debug, it showed me the offset:
```
❯ plistutil -i "$PWD/layout/Library/Application Support/YouPiP.bundle/zh_tw.lproj/Localizable.strings" -f bin -o "test.string"
libplist[ostepparser] ERROR: Unexpected character when parsing unquoted string at offset 0
ERROR: Could not parse plist data (-3)
```

Hexdump confirmed that there is an extra characters in the beginning:
```
❯ hexdump -C "$PWD/layout/Library/Application Support/YouPiP.bundle/zh_tw.lproj/Localizable.strings"
00000000  ef bb bf 22 53 45 54 54  49 4e 47 53 5f 54 49 54  |..."SETTINGS_TIT|
00000010  4c 45 22 20 3d 20 22 59  6f 75 50 69 50 22 3b 0a  |LE" = "YouPiP";.|
00000020  0a 22 45 4e 41 42 4c 45  44 22 20 3d 20 22 e5 95  |."ENABLED" = "..|
00000030  9f e7 94 a8 22 3b 0a 22  45 4e 41 42 4c 45 44 5f  |....";."ENABLED_|
```

Other localizations don't have this symbols:
```
❯ hexdump -C "$PWD/layout/Library/Application Support/YouPiP.bundle/zh_cn.lproj/Localizable.strings"
00000000  22 53 45 54 54 49 4e 47  53 5f 54 49 54 4c 45 22  |"SETTINGS_TITLE"|
00000010  20 3d 20 22 59 6f 75 50  69 50 22 3b 0a 0a 22 45  | = "YouPiP";.."E|
00000020  4e 41 42 4c 45 44 22 20  3d 20 22 e5 90 af e7 94  |NABLED" = ".....|
00000030  a8 22 3b 0a 22 45 4e 41  42 4c 45 44 5f 44 45 53  |.";."ENABLED_DES|
```